### PR TITLE
Fixed PARALLEL_JOBS_OPTS so parallel build works.

### DIFF
--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -46,7 +46,7 @@ else()
 endif()
 
 if (${CMAKE_VERSION} VERSION_GREATER 3.11.4)
-  set(PARALLEL_JOBS_OPTS -j ${BUILD_JOBS})
+  set(PARALLEL_JOBS_OPTS -- -j ${BUILD_JOBS})
 endif()
 
 set(DEFAULT_BUILD_COMMAND cmake --build . --config Release ${PARALLEL_JOBS_OPTS})


### PR DESCRIPTION
I tried using the superbuild and ran into a problem where zlib and ilmbase could not do parallel make.

git clone https://github.com/openvkl/openvkl.git
mkdir openvkl/build
cd openvkl/build
/opt/cmake-3.16.4/bin/cmake  -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DCMAKE_BUILD_TYPE=Release -DBUILD_JOBS=32 -DCMAKE_INSTALL_PREFIX=$HOME/thirdparty/openvkl ../superbuild
/opt/cmake-3.16.4/bin/cmake --build .

This failed almost immediately in zlib.

The problem appears to be in openvkl/superbuild/CMakeLists.txt. I changed these lines:

if (${CMAKE_VERSION} VERSION_GREATER 3.11.4)
  set(PARALLEL_JOBS_OPTS -j ${BUILD_JOBS})
endif()

I added -- to pass subsequent arguments to the underlying build.

if (${CMAKE_VERSION} VERSION_GREATER 3.11.4)
  set(PARALLEL_JOBS_OPTS -- -j ${BUILD_JOBS})
endif()
