### PR TITLE
Fix CMake install location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,8 @@ configure_file(
 
 include_directories_ispc(${CMAKE_CURRENT_BINARY_DIR}/openvkl/include/${PROJECT_NAME})
 
+include(GNUInstallDirs)
+
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/openvkl/include/${PROJECT_NAME}/version.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
 )
@@ -48,7 +50,6 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/openvkl/include/${PROJECT_NAME}/versio
 option(BUILD_EXAMPLES "Build example applications." ON)
 option(BUILD_BENCHMARKS "Build benchmark applications." OFF)
 
-include(GNUInstallDirs)
 include(CTest) # Adds 'BUILD_TESTING' variable
 
 if (BUILD_TESTING)


### PR DESCRIPTION
`GNUInstallDirs` needs to be included before `CMAKE_INSTALL_INCLUDEDIR` can be used. This fixes the following error (full logs [here](https://github.com/Homebrew/homebrew-core/actions/runs/4371774358/jobs/7648037123), error starts [here](https://github.com/Homebrew/homebrew-core/actions/runs/4371774358/jobs/7648037123#step:7:601)):

```
  Install the project...
  /opt/homebrew/Cellar/cmake/3.25.3/bin/cmake -P cmake_install.cmake
  -- Install configuration: "Release"
  CMake Error at cmake_install.cmake:49 (file):
    file cannot create directory: /openvkl.  Maybe need administrative
    privileges.
```

The error was seen in https://github.com/Homebrew/homebrew-core/pull/123269 while packaging [OSPRay](https://github.com/ospray/ospray), an Open VKL dependant, for Homebrew.

Fixes #19.
